### PR TITLE
Add dbcounter plugin and unit test

### DIFF
--- a/plugins/aggregators/all/dbcounter.go
+++ b/plugins/aggregators/all/dbcounter.go
@@ -1,0 +1,5 @@
+//go:build !custom || aggregators || aggregators.dbcounter
+
+package all
+
+import _ "github.com/influxdata/telegraf/plugins/aggregators/dbcounter" // register plugin

--- a/plugins/aggregators/dbcounter/README.md
+++ b/plugins/aggregators/dbcounter/README.md
@@ -1,0 +1,3 @@
+# Databricks Counter Aggregator Plugin
+
+TODO

--- a/plugins/aggregators/dbcounter/dbcounter.go
+++ b/plugins/aggregators/dbcounter/dbcounter.go
@@ -55,7 +55,7 @@ func (*Aggregator) SampleConfig() string {
 
 func NewAggregator() *Aggregator {
 	a := &Aggregator{
-		outputNameSuffix:      "_dbcounter",
+		outputNameSuffix:      "",
 		excludeByLabels:       make([]string, 0),
 		lateSeriesGracePeriod: config.Duration(5 * time.Minute),
 		aggregationInterval:   config.Duration(30 * time.Second),

--- a/plugins/aggregators/dbcounter/dbcounter.go
+++ b/plugins/aggregators/dbcounter/dbcounter.go
@@ -1,0 +1,228 @@
+//go:generate ../../../tools/readme_config_includer/generator
+package dbcounter
+
+// dbcounter.go
+
+import (
+	_ "embed"
+	"fmt"
+	"hash/fnv"
+	"sort"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/aggregators"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type DeltaAggregate struct {
+	Name             string
+	Tags             map[string]string
+	LastValue        float64
+	ThisValue        float64
+	SeenInLastWindow bool
+	Time             time.Time
+}
+
+type SumAggregate struct {
+	Name         string
+	Tags         map[string]string
+	Value        float64
+	FirstSeen    bool
+	SeenInWindow bool
+	Time         time.Time
+}
+
+type Aggregator struct {
+	deltaState          map[uint64]*DeltaAggregate `toml:"-"`
+	sumState            map[uint64]*SumAggregate   `toml:"-"`
+	outputNameSuffix    string                     `toml:"output_name_suffix"`
+	excludeByLabels     []string                   `toml:"exclude_by_labels"`
+	lateSeriesGrace     config.Duration            `toml:"late_series_grace"`
+	aggregationInterval config.Duration            `toml:"period"`
+	Log                 telegraf.Logger            `toml:"-"`
+}
+
+func (*Aggregator) SampleConfig() string {
+	return sampleConfig
+}
+
+func NewAggregator() *Aggregator {
+	a := &Aggregator{
+		outputNameSuffix:    "_dbcounter",
+		excludeByLabels:     make([]string, 0),
+		lateSeriesGrace:     config.Duration(5 * time.Minute),
+		aggregationInterval: config.Duration(30 * time.Second),
+	}
+	a.Reset()
+	return a
+}
+
+func (a *Aggregator) Init() error {
+	if a.excludeByLabels == nil || len(a.excludeByLabels) == 0 {
+		return fmt.Errorf("exclude_by_labels must be set and non-empty")
+	}
+	a.deltaState = make(map[uint64]*DeltaAggregate)
+	a.sumState = make(map[uint64]*SumAggregate)
+	a.Log.Debug("dbcounter aggregator inited")
+	return nil
+}
+
+func (a *Aggregator) Add(metric telegraf.Metric) {
+	fieldList := metric.FieldList()
+	if fieldList == nil || len(fieldList) != 1 {
+		return
+	}
+	firstField := fieldList[0]
+	if firstField.Key != "value" {
+		return
+	}
+	value, ok := convert(firstField.Value)
+	if !ok {
+		return
+	}
+
+	metricName := metric.Name()
+	tags := metric.Tags()
+	deltaGroupID := generateGroupID(metricName, tags)
+	deltaAgg, found := a.deltaState[deltaGroupID]
+	if !found {
+		deltaAgg = &DeltaAggregate{
+			Name:             metricName,
+			Tags:             tags, // TODO: deep copy tags
+			LastValue:        -1,   // counter never negative, we use negative to indicate uninitialized
+			ThisValue:        value,
+			SeenInLastWindow: true,
+			Time:             metric.Time(),
+		}
+		a.deltaState[deltaGroupID] = deltaAgg
+	} else {
+		deltaAgg.SeenInLastWindow = true
+		deltaAgg.LastValue = deltaAgg.ThisValue
+		deltaAgg.ThisValue = value
+		deltaAgg.Time = metric.Time()
+	}
+
+	delta := computeDelta(deltaAgg.LastValue, deltaAgg.ThisValue)
+
+	newTags := make(map[string]string)
+	for k, v := range tags {
+		if !contains(a.excludeByLabels, k) {
+			newTags[k] = v
+		}
+	}
+
+	sumGroupID := generateGroupID(metricName, newTags)
+	sumAgg, found := a.sumState[sumGroupID]
+	if !found {
+		sumAgg = &SumAggregate{
+			Name:         metricName,
+			Tags:         newTags,
+			Value:        delta,
+			FirstSeen:    true,
+			SeenInWindow: true,
+			Time:         metric.Time(),
+		}
+		a.sumState[sumGroupID] = sumAgg
+	} else {
+		sumAgg.SeenInWindow = true
+		sumAgg.Value += delta
+		sumAgg.Time = metric.Time()
+	}
+}
+
+func (a *Aggregator) Push(acc telegraf.Accumulator) {
+	now := time.Now()
+	for _, sumAgg := range a.sumState {
+		if !sumAgg.SeenInWindow {
+			continue
+		}
+		nameWithSuffix := sumAgg.Name + a.outputNameSuffix
+		if sumAgg.FirstSeen {
+			acc.AddFields(nameWithSuffix, map[string]interface{}{"value": float64(0)}, sumAgg.Tags, now.Add(-time.Duration(a.aggregationInterval)/2))
+		}
+		acc.AddFields(nameWithSuffix, map[string]interface{}{"value": sumAgg.Value}, sumAgg.Tags, now)
+	}
+}
+
+func (a *Aggregator) Reset() {
+	now := time.Now()
+	for id, deltaAgg := range a.deltaState {
+		if now.Sub(deltaAgg.Time) > time.Duration(a.lateSeriesGrace) {
+			delete(a.deltaState, id)
+			continue
+		}
+		deltaAgg.SeenInLastWindow = false
+	}
+
+	for id, sumAgg := range a.sumState {
+		if now.Sub(sumAgg.Time) > time.Duration(a.lateSeriesGrace) {
+			delete(a.sumState, id)
+			continue
+		}
+		sumAgg.SeenInWindow = false
+		sumAgg.FirstSeen = false
+	}
+}
+
+func computeDelta(last, current float64) float64 {
+	if last < 0 || current < 0 {
+		return 0
+	}
+	delta := current - last
+	if delta < 0 {
+		delta = 0
+	}
+	return delta
+}
+
+func generateGroupID(name string, tags map[string]string) uint64 {
+	h := fnv.New64a()     // Initialize FNV-1a hasher
+	h.Write([]byte(name)) // Hash metric name
+
+	sortedKeys := make([]string, 0, len(tags))
+	for k := range tags {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys) // Ensure consistent ordering
+
+	for _, k := range sortedKeys {
+		h.Write([]byte(k))       // Hash tag key
+		h.Write([]byte("="))     // Separator
+		h.Write([]byte(tags[k])) // Hash tag value
+		h.Write([]byte(";"))     // Separator for safety
+	}
+
+	return h.Sum64()
+}
+
+func convert(in interface{}) (float64, bool) {
+	switch v := in.(type) {
+	case float64:
+		return v, true
+	case int64:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	default:
+		return 0, false
+	}
+}
+
+func contains(slice []string, value string) bool {
+	for _, v := range slice {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}
+
+func init() {
+	aggregators.Add("dbcounter", func() telegraf.Aggregator {
+		return NewAggregator()
+	})
+}

--- a/plugins/aggregators/dbcounter/dbcounter.go
+++ b/plugins/aggregators/dbcounter/dbcounter.go
@@ -202,6 +202,7 @@ func generateGroupID(name string, tags map[string]string) uint64 {
 	return h.Sum64()
 }
 
+// Every aggregator has this convert func, we just steal it from other implementations
 func convert(in interface{}) (float64, bool) {
 	switch v := in.(type) {
 	case float64:

--- a/plugins/aggregators/dbcounter/dbcounter_test.go
+++ b/plugins/aggregators/dbcounter/dbcounter_test.go
@@ -1,0 +1,94 @@
+package dbcounter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimple(t *testing.T) {
+	acc := testutil.Accumulator{}
+	agg := NewAggregator()
+	agg.excludeByLabels = []string{"dbletNode"}
+	agg.Log = testutil.Logger{}
+
+	require.NoError(t, agg.Init())
+
+	m1 := metric.New("m1",
+		map[string]string{"foo": "bar", "dbletNode": "node1"},
+		map[string]interface{}{"value": float64(1)},
+		time.Unix(1530939936, 0))
+	m2 := metric.New("m1",
+		map[string]string{"foo": "bar", "dbletNode": "node1"},
+		map[string]interface{}{"value": float64(2)},
+		time.Unix(1530939937, 0))
+	m3 := metric.New("m1",
+		map[string]string{"foo": "bar", "dbletNode": "node1"},
+		map[string]interface{}{"value": float64(3)},
+		time.Unix(1530939938, 0))
+	agg.Add(m1)
+	agg.Add(m2)
+	agg.Add(m3)
+	agg.Push(&acc)
+
+	expectedName := "m1_dbcounter"
+	expectedTags := map[string]string{
+		"foo": "bar",
+	}
+	expectedValues := []map[string]interface{}{
+		{
+			"value": float64(0),
+		},
+		{
+			"value": float64(2),
+		},
+	}
+	for _, expectValue := range expectedValues {
+		acc.AssertContainsTaggedFields(
+			t,
+			expectedName,
+			expectValue,
+			expectedTags,
+		)
+	}
+}
+
+func TestDeltaHandling(t *testing.T) {
+	acc := testutil.Accumulator{}
+	agg := NewAggregator()
+	agg.excludeByLabels = []string{"dbletNode"}
+	agg.Log = testutil.Logger{}
+
+	require.NoError(t, agg.Init())
+
+	m1 := metric.New("m1",
+		map[string]string{"foo": "bar", "dbletNode": "node1"},
+		map[string]interface{}{"value": float64(99)},
+		time.Unix(1530939936, 0))
+	agg.Add(m1)
+	agg.Push(&acc)
+
+	expectedName := "m1_dbcounter"
+	expectedTags := map[string]string{
+		"foo": "bar",
+	}
+	expectedValues := []map[string]interface{}{
+		{
+			"value": float64(0),
+		},
+		{
+			"value": float64(0),
+		},
+	}
+	for _, expectValue := range expectedValues {
+		acc.AssertContainsTaggedFields(
+			t,
+			expectedName,
+			expectValue,
+			expectedTags,
+		)
+	}
+}

--- a/plugins/aggregators/dbcounter/dbcounter_test.go
+++ b/plugins/aggregators/dbcounter/dbcounter_test.go
@@ -11,11 +11,7 @@ import (
 
 func TestSimple(t *testing.T) {
 	acc := testutil.Accumulator{}
-	agg := NewAggregator()
-	agg.excludeByLabels = []string{"dbletNode"}
-	agg.Log = testutil.Logger{}
-
-	require.NoError(t, agg.Init())
+	agg := newAggregator(t)
 
 	m1 := metric.New("m1",
 		map[string]string{"foo": "bar", "dbletNode": "node1"},
@@ -58,11 +54,7 @@ func TestSimple(t *testing.T) {
 
 func TestDeltaHandling(t *testing.T) {
 	acc := testutil.Accumulator{}
-	agg := NewAggregator()
-	agg.excludeByLabels = []string{"dbletNode"}
-	agg.Log = testutil.Logger{}
-
-	require.NoError(t, agg.Init())
+	agg := newAggregator(t)
 
 	m1 := metric.New("m1",
 		map[string]string{"foo": "bar", "dbletNode": "node1"},
@@ -91,4 +83,57 @@ func TestDeltaHandling(t *testing.T) {
 			expectedTags,
 		)
 	}
+}
+
+func TestLabelDropping(t *testing.T) {
+	acc := testutil.Accumulator{}
+	agg := newAggregator(t)
+
+	m1 := metric.New("m1",
+		map[string]string{"foo": "bar", "dbletNode": "node1"},
+		map[string]interface{}{"value": float64(1)},
+		time.Unix(1530939936, 0))
+	m2 := metric.New("m1",
+		map[string]string{"foo": "bar", "dbletNode": "node2"},
+		map[string]interface{}{"value": float64(2)},
+		time.Unix(1530939937, 0))
+	m3 := metric.New("m1",
+		map[string]string{"foo": "bar", "dbletNode": "node2"},
+		map[string]interface{}{"value": float64(3)},
+		time.Unix(1530939938, 0))
+	agg.Add(m1)
+	agg.Add(m2)
+	agg.Add(m3)
+	agg.Push(&acc)
+
+	expectedName := "m1_dbcounter"
+	expectedTags := map[string]string{
+		"foo": "bar",
+	}
+	expectedValues := []map[string]interface{}{
+		{
+			"value": float64(0),
+		},
+		{
+			"value": float64(1),
+		},
+	}
+	for _, expectValue := range expectedValues {
+		acc.AssertContainsTaggedFields(
+			t,
+			expectedName,
+			expectValue,
+			expectedTags,
+		)
+	}
+}
+
+func newAggregator(t *testing.T) *Aggregator {
+	agg := NewAggregator()
+	agg.outputNameSuffix = "_dbcounter"
+	agg.excludeByLabels = []string{"dbletNode"}
+	agg.Log = testutil.Logger{}
+
+	require.NoError(t, agg.Init())
+	return agg
 }

--- a/plugins/aggregators/dbcounter/dbcounter_test.go
+++ b/plugins/aggregators/dbcounter/dbcounter_test.go
@@ -22,7 +22,10 @@ type testAggregationWindow struct {
 }
 
 const (
-	startOfTheWorld = 1530939936
+	startOfTheWorld  = 1530939936
+	outputNameSuffix = "_dbcounter"
+	excludeByLabel   = "dbletNode"
+	testMeasurement  = "m1"
 )
 
 func TestSimple(t *testing.T) {
@@ -33,25 +36,25 @@ func TestSimple(t *testing.T) {
 			windows: []testAggregationWindow{
 				{
 					metricsInput: []telegraf.Metric{
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(1)},
 							timeFromOffset(0)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(2)},
 							timeFromOffset(1)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(3)},
 							timeFromOffset(2)),
 					},
 					expectedMetricsOutput: []telegraf.Metric{
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(0)},
 							timeFromOffset(0)),
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(2)},
 							timeFromOffset(0)),
@@ -87,21 +90,21 @@ func TestMultipleWindows(t *testing.T) {
 			windows: []testAggregationWindow{
 				{
 					metricsInput: []telegraf.Metric{
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(1)},
 							timeFromOffset(0)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(3)},
 							timeFromOffset(1)),
 					},
 					expectedMetricsOutput: []telegraf.Metric{
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(0)},
 							timeFromOffset(0)),
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(2)},
 							timeFromOffset(0)),
@@ -109,17 +112,17 @@ func TestMultipleWindows(t *testing.T) {
 				},
 				{
 					metricsInput: []telegraf.Metric{
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(7)},
 							timeFromOffset(2)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(15)},
 							timeFromOffset(3)),
 					},
 					expectedMetricsOutput: []telegraf.Metric{
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(14)},
 							timeFromOffset(2)),
@@ -133,29 +136,29 @@ func TestMultipleWindows(t *testing.T) {
 			windows: []testAggregationWindow{
 				{
 					metricsInput: []telegraf.Metric{
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(1)},
 							timeFromOffset(0)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node2"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node2"},
 							map[string]interface{}{"value": float64(2)},
 							timeFromOffset(0)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(3)},
 							timeFromOffset(1)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node2"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node2"},
 							map[string]interface{}{"value": float64(4)},
 							timeFromOffset(1)),
 					},
 					expectedMetricsOutput: []telegraf.Metric{
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(0)},
 							timeFromOffset(0)),
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(4)},
 							timeFromOffset(0)),
@@ -163,25 +166,25 @@ func TestMultipleWindows(t *testing.T) {
 				},
 				{
 					metricsInput: []telegraf.Metric{
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(7)},
 							timeFromOffset(2)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node2"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node2"},
 							map[string]interface{}{"value": float64(8)},
 							timeFromOffset(2)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(9)},
 							timeFromOffset(3)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node2"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node2"},
 							map[string]interface{}{"value": float64(10)},
 							timeFromOffset(3)),
 					},
 					expectedMetricsOutput: []telegraf.Metric{
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(16)},
 							timeFromOffset(2)),
@@ -216,17 +219,17 @@ func TestDeltaEdgeCases(t *testing.T) {
 			windows: []testAggregationWindow{
 				{
 					metricsInput: []telegraf.Metric{
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(999)},
 							timeFromOffset(0)),
 					},
 					expectedMetricsOutput: []telegraf.Metric{
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(0)},
 							time.Unix(0, 0)),
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(0)},
 							time.Unix(0, 0)),
@@ -240,25 +243,25 @@ func TestDeltaEdgeCases(t *testing.T) {
 			windows: []testAggregationWindow{
 				{
 					metricsInput: []telegraf.Metric{
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(9)},
 							timeFromOffset(0)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node2"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node2"},
 							map[string]interface{}{"value": float64(99)},
 							timeFromOffset(1)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node3"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node3"},
 							map[string]interface{}{"value": float64(999)},
 							timeFromOffset(2)),
 					},
 					expectedMetricsOutput: []telegraf.Metric{
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(0)},
 							timeFromOffset(0)),
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(0)},
 							timeFromOffset(0)),
@@ -272,29 +275,29 @@ func TestDeltaEdgeCases(t *testing.T) {
 			windows: []testAggregationWindow{
 				{
 					metricsInput: []telegraf.Metric{
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(99)},
 							timeFromOffset(0)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(100)},
 							timeFromOffset(1)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(3)},
 							timeFromOffset(2)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(5)},
 							timeFromOffset(3)),
 					},
 					expectedMetricsOutput: []telegraf.Metric{
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(0)},
 							timeFromOffset(0)),
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64((100 - 99) + (5 - 3))},
 							timeFromOffset(0)),
@@ -308,21 +311,21 @@ func TestDeltaEdgeCases(t *testing.T) {
 			windows: []testAggregationWindow{
 				{
 					metricsInput: []telegraf.Metric{
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(99)},
 							timeFromOffset(0)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(100)},
 							timeFromOffset(1)),
 					},
 					expectedMetricsOutput: []telegraf.Metric{
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(0)},
 							timeFromOffset(0)),
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(100 - 99)},
 							timeFromOffset(0)),
@@ -330,21 +333,21 @@ func TestDeltaEdgeCases(t *testing.T) {
 				},
 				{
 					metricsInput: []telegraf.Metric{
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(101)},
 							timeFromOffset(2)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(4)},
 							timeFromOffset(3)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(5)},
 							timeFromOffset(4)),
 					},
 					expectedMetricsOutput: []telegraf.Metric{
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64((100 - 99) + (101 - 100) + 0 + (5 - 4))},
 							timeFromOffset(0)),
@@ -379,29 +382,29 @@ func TestLabelDropping(t *testing.T) {
 			windows: []testAggregationWindow{
 				{
 					metricsInput: []telegraf.Metric{
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(1)},
 							timeFromOffset(0)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node1"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node1"},
 							map[string]interface{}{"value": float64(2)},
 							timeFromOffset(0)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node2"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node2"},
 							map[string]interface{}{"value": float64(3)},
 							timeFromOffset(1)),
-						metric.New("m1",
-							map[string]string{"foo": "bar", "dbletNode": "node2"},
+						metric.New(testMeasurement,
+							map[string]string{"foo": "bar", excludeByLabel: "node2"},
 							map[string]interface{}{"value": float64(4)},
 							timeFromOffset(2)),
 					},
 					expectedMetricsOutput: []telegraf.Metric{
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(0)},
 							timeFromOffset(0)),
-						metric.New("m1_dbcounter",
+						metric.New(testMeasurement+outputNameSuffix,
 							map[string]string{"foo": "bar"},
 							map[string]interface{}{"value": float64(2)},
 							timeFromOffset(0)),
@@ -430,8 +433,8 @@ func TestLabelDropping(t *testing.T) {
 
 func newAggregator(t *testing.T) *Aggregator {
 	agg := NewAggregator()
-	agg.outputNameSuffix = "_dbcounter"
-	agg.excludeByLabels = []string{"dbletNode"}
+	agg.OutputNameSuffix = outputNameSuffix
+	agg.ExcludeByLabels = []string{excludeByLabel}
 	agg.Log = testutil.Logger{}
 
 	require.NoError(t, agg.Init())

--- a/plugins/aggregators/dbcounter/dbcounter_test.go
+++ b/plugins/aggregators/dbcounter/dbcounter_test.go
@@ -4,127 +4,208 @@ import (
 	"testing"
 	"time"
 
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 )
 
+type testCase struct {
+	name        string
+	description string
+	windows     []testAggregationWindow
+}
+
+type testAggregationWindow struct {
+	metricsInput          []telegraf.Metric
+	expectedMetricsOutput []telegraf.Metric
+}
+
 func TestSimple(t *testing.T) {
-	acc := testutil.Accumulator{}
-	agg := newAggregator(t)
-
-	m1 := metric.New("m1",
-		map[string]string{"foo": "bar", "dbletNode": "node1"},
-		map[string]interface{}{"value": float64(1)},
-		time.Unix(1530939936, 0))
-	m2 := metric.New("m1",
-		map[string]string{"foo": "bar", "dbletNode": "node1"},
-		map[string]interface{}{"value": float64(2)},
-		time.Unix(1530939937, 0))
-	m3 := metric.New("m1",
-		map[string]string{"foo": "bar", "dbletNode": "node1"},
-		map[string]interface{}{"value": float64(3)},
-		time.Unix(1530939938, 0))
-	agg.Add(m1)
-	agg.Add(m2)
-	agg.Add(m3)
-	agg.Push(&acc)
-
-	expectedName := "m1_dbcounter"
-	expectedTags := map[string]string{
-		"foo": "bar",
-	}
-	expectedValues := []map[string]interface{}{
+	testCases := []testCase{
 		{
-			"value": float64(0),
-		},
-		{
-			"value": float64(2),
+			name:        "simple counter increment",
+			description: "arrival of 2 and 3 each brings a delta of 1, making a total of 2",
+			windows: []testAggregationWindow{
+				{
+					metricsInput: []telegraf.Metric{
+						metric.New("m1",
+							map[string]string{"foo": "bar", "dbletNode": "node1"},
+							map[string]interface{}{"value": float64(1)},
+							time.Unix(1530939936, 0)),
+						metric.New("m1",
+							map[string]string{"foo": "bar", "dbletNode": "node1"},
+							map[string]interface{}{"value": float64(2)},
+							time.Unix(1530939937, 0)),
+						metric.New("m1",
+							map[string]string{"foo": "bar", "dbletNode": "node1"},
+							map[string]interface{}{"value": float64(3)},
+							time.Unix(1530939938, 0)),
+					},
+					expectedMetricsOutput: []telegraf.Metric{
+						metric.New("m1_dbcounter",
+							map[string]string{"foo": "bar"},
+							map[string]interface{}{"value": float64(0)},
+							time.Unix(0, 0)),
+						metric.New("m1_dbcounter",
+							map[string]string{"foo": "bar"},
+							map[string]interface{}{"value": float64(2)},
+							time.Unix(0, 0)),
+					},
+				},
+			},
 		},
 	}
-	for _, expectValue := range expectedValues {
-		acc.AssertContainsTaggedFields(
-			t,
-			expectedName,
-			expectValue,
-			expectedTags,
-		)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			acc := &testutil.Accumulator{}
+			agg := newAggregator(t)
+
+			for _, window := range tc.windows {
+
+				for _, m := range window.metricsInput {
+					agg.Add(m)
+				}
+				agg.Push(acc)
+
+				check(t, acc, window.expectedMetricsOutput)
+			}
+		})
 	}
 }
 
-func TestDeltaHandling(t *testing.T) {
-	acc := testutil.Accumulator{}
-	agg := newAggregator(t)
-
-	m1 := metric.New("m1",
-		map[string]string{"foo": "bar", "dbletNode": "node1"},
-		map[string]interface{}{"value": float64(99)},
-		time.Unix(1530939936, 0))
-	agg.Add(m1)
-	agg.Push(&acc)
-
-	expectedName := "m1_dbcounter"
-	expectedTags := map[string]string{
-		"foo": "bar",
-	}
-	expectedValues := []map[string]interface{}{
+func TestDeltaEdgeCases(t *testing.T) {
+	testCases := []testCase{
 		{
-			"value": float64(0),
+			name:        "single sample point in a window",
+			description: "should return 0, 0",
+			windows: []testAggregationWindow{
+				{
+					metricsInput: []telegraf.Metric{
+						metric.New("m1",
+							map[string]string{"foo": "bar", "dbletNode": "node1"},
+							map[string]interface{}{"value": float64(999)},
+							time.Unix(1530939936, 0)),
+					},
+					expectedMetricsOutput: []telegraf.Metric{
+						metric.New("m1_dbcounter",
+							map[string]string{"foo": "bar"},
+							map[string]interface{}{"value": float64(0)},
+							time.Unix(0, 0)),
+						metric.New("m1_dbcounter",
+							map[string]string{"foo": "bar"},
+							map[string]interface{}{"value": float64(0)},
+							time.Unix(0, 0)),
+					},
+				},
+			},
 		},
 		{
-			"value": float64(0),
+			name:        "single sample point in a window, multiple nodes",
+			description: "should still return 0, 0",
+			windows: []testAggregationWindow{
+				{
+					metricsInput: []telegraf.Metric{
+						metric.New("m1",
+							map[string]string{"foo": "bar", "dbletNode": "node1"},
+							map[string]interface{}{"value": float64(9)},
+							time.Unix(1530939936, 0)),
+						metric.New("m1",
+							map[string]string{"foo": "bar", "dbletNode": "node2"},
+							map[string]interface{}{"value": float64(99)},
+							time.Unix(1530939937, 0)),
+						metric.New("m1",
+							map[string]string{"foo": "bar", "dbletNode": "node3"},
+							map[string]interface{}{"value": float64(999)},
+							time.Unix(1530939938, 0)),
+					},
+					expectedMetricsOutput: []telegraf.Metric{
+						metric.New("m1_dbcounter",
+							map[string]string{"foo": "bar"},
+							map[string]interface{}{"value": float64(0)},
+							time.Unix(0, 0)),
+						metric.New("m1_dbcounter",
+							map[string]string{"foo": "bar"},
+							map[string]interface{}{"value": float64(0)},
+							time.Unix(0, 0)),
+					},
+				},
+			},
 		},
 	}
-	for _, expectValue := range expectedValues {
-		acc.AssertContainsTaggedFields(
-			t,
-			expectedName,
-			expectValue,
-			expectedTags,
-		)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			acc := &testutil.Accumulator{}
+			agg := newAggregator(t)
+
+			for _, window := range tc.windows {
+				for _, m := range window.metricsInput {
+					agg.Add(m)
+				}
+				agg.Push(acc)
+
+				check(t, acc, window.expectedMetricsOutput)
+			}
+		})
 	}
 }
 
 func TestLabelDropping(t *testing.T) {
-	acc := testutil.Accumulator{}
-	agg := newAggregator(t)
-
-	m1 := metric.New("m1",
-		map[string]string{"foo": "bar", "dbletNode": "node1"},
-		map[string]interface{}{"value": float64(1)},
-		time.Unix(1530939936, 0))
-	m2 := metric.New("m1",
-		map[string]string{"foo": "bar", "dbletNode": "node2"},
-		map[string]interface{}{"value": float64(2)},
-		time.Unix(1530939937, 0))
-	m3 := metric.New("m1",
-		map[string]string{"foo": "bar", "dbletNode": "node2"},
-		map[string]interface{}{"value": float64(3)},
-		time.Unix(1530939938, 0))
-	agg.Add(m1)
-	agg.Add(m2)
-	agg.Add(m3)
-	agg.Push(&acc)
-
-	expectedName := "m1_dbcounter"
-	expectedTags := map[string]string{
-		"foo": "bar",
-	}
-	expectedValues := []map[string]interface{}{
+	testCases := []testCase{
 		{
-			"value": float64(0),
-		},
-		{
-			"value": float64(1),
+			name:        "label dropping for dbletNode",
+			description: "output should not have dbletNode label and should combine delta from all nodes",
+			windows: []testAggregationWindow{
+				{
+					metricsInput: []telegraf.Metric{
+						metric.New("m1",
+							map[string]string{"foo": "bar", "dbletNode": "node1"},
+							map[string]interface{}{"value": float64(1)},
+							time.Unix(1530939936, 0)),
+						metric.New("m1",
+							map[string]string{"foo": "bar", "dbletNode": "node1"},
+							map[string]interface{}{"value": float64(2)},
+							time.Unix(1530939936, 0)),
+						metric.New("m1",
+							map[string]string{"foo": "bar", "dbletNode": "node2"},
+							map[string]interface{}{"value": float64(3)},
+							time.Unix(1530939937, 0)),
+						metric.New("m1",
+							map[string]string{"foo": "bar", "dbletNode": "node2"},
+							map[string]interface{}{"value": float64(4)},
+							time.Unix(1530939938, 0)),
+					},
+					expectedMetricsOutput: []telegraf.Metric{
+						metric.New("m1_dbcounter",
+							map[string]string{"foo": "bar"},
+							map[string]interface{}{"value": float64(0)},
+							time.Unix(0, 0)),
+						metric.New("m1_dbcounter",
+							map[string]string{"foo": "bar"},
+							map[string]interface{}{"value": float64(2)},
+							time.Unix(0, 0)),
+					},
+				},
+			},
 		},
 	}
-	for _, expectValue := range expectedValues {
-		acc.AssertContainsTaggedFields(
-			t,
-			expectedName,
-			expectValue,
-			expectedTags,
-		)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			acc := &testutil.Accumulator{}
+			agg := newAggregator(t)
+
+			for _, window := range tc.windows {
+				for _, m := range window.metricsInput {
+					agg.Add(m)
+				}
+				agg.Push(acc)
+
+				check(t, acc, window.expectedMetricsOutput)
+			}
+		})
 	}
 }
 
@@ -136,4 +217,16 @@ func newAggregator(t *testing.T) *Aggregator {
 
 	require.NoError(t, agg.Init())
 	return agg
+}
+
+func check(t *testing.T, acc *testutil.Accumulator, expectedMetrics []telegraf.Metric) {
+	// Not checking the order of the metrics and not checking the timestamp of the metrics
+	for _, expectedMetric := range expectedMetrics {
+		acc.AssertContainsTaggedFields(
+			t,
+			expectedMetric.Name(),
+			expectedMetric.Fields(),
+			expectedMetric.Tags(),
+		)
+	}
 }

--- a/plugins/aggregators/dbcounter/sample.conf
+++ b/plugins/aggregators/dbcounter/sample.conf
@@ -8,10 +8,11 @@
   # drop_original = false
 
   ## Configures which labels to group without
-  # exclude_by_labels = ["dbletNode"]
+  exclude_by_labels = ["dbletNode"]
 
   ## Configures a suffix to append to all output metrics, can be empty string
-  # output_name_suffix = "_dbcounter"
+  ##   example: output_name_suffix = "_dbcounter"
+  output_name_suffix = ""
 
   ## time we will wait before marking a series as dead
   # late_series_grace_period = "5m"

--- a/plugins/aggregators/dbcounter/sample.conf
+++ b/plugins/aggregators/dbcounter/sample.conf
@@ -1,4 +1,4 @@
-# Keep the aggregate basicstats of each metric passing through.
+# Custom counter aggregator for Databricks.
 [[aggregators.dbcounter]]
   ## The period on which to flush & clear the aggregator.
   # period = "30s"

--- a/plugins/aggregators/dbcounter/sample.conf
+++ b/plugins/aggregators/dbcounter/sample.conf
@@ -1,0 +1,18 @@
+# Keep the aggregate basicstats of each metric passing through.
+[[aggregators.dbcounter]]
+  ## The period on which to flush & clear the aggregator.
+  # period = "30s"
+
+  ## If true, the original metric will be dropped by the
+  ## aggregator and will not get sent to the output plugins.
+  # drop_original = false
+
+  ## Configures which labels to group without
+  # exclude_by_labels = ["dbletNode"]
+
+  ## Configures a suffix to append to all output metrics, can be empty string
+  # output_name_suffix = "_dbcounter"
+
+  ## time we will wait before marking a series as dead
+  # late_series_grace_period = "5m"
+


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

unit test passes

```
yu.long@HH9DQ02X5W telegraf-fork % go test -v ./plugins/aggregators/dbcounter/.
=== RUN   TestSimple
=== RUN   TestSimple/simple_counter_increment
--- PASS: TestSimple (0.00s)
    --- PASS: TestSimple/simple_counter_increment (0.00s)
=== RUN   TestMultipleWindows
=== RUN   TestMultipleWindows/multiple_windows
=== RUN   TestMultipleWindows/multiple_windows_multiple_nodes
--- PASS: TestMultipleWindows (0.00s)
    --- PASS: TestMultipleWindows/multiple_windows (0.00s)
    --- PASS: TestMultipleWindows/multiple_windows_multiple_nodes (0.00s)
=== RUN   TestDeltaEdgeCases
=== RUN   TestDeltaEdgeCases/single_sample_point_in_a_window
=== RUN   TestDeltaEdgeCases/single_sample_point_in_a_window,_multiple_nodes
=== RUN   TestDeltaEdgeCases/real_counter_reset
=== RUN   TestDeltaEdgeCases/real_counter_reset_across_two_windows
--- PASS: TestDeltaEdgeCases (0.00s)
    --- PASS: TestDeltaEdgeCases/single_sample_point_in_a_window (0.00s)
    --- PASS: TestDeltaEdgeCases/single_sample_point_in_a_window,_multiple_nodes (0.00s)
    --- PASS: TestDeltaEdgeCases/real_counter_reset (0.00s)
    --- PASS: TestDeltaEdgeCases/real_counter_reset_across_two_windows (0.00s)
=== RUN   TestLabelDropping
=== RUN   TestLabelDropping/label_dropping_for_dbletNode
--- PASS: TestLabelDropping (0.00s)
    --- PASS: TestLabelDropping/label_dropping_for_dbletNode (0.00s)
PASS
ok      github.com/influxdata/telegraf/plugins/aggregators/dbcounter    0.644s

```

e2e test in https://github.com/databricks-eng/universe/pull/892702



## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
